### PR TITLE
Remove codex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Changelog
 
-## UPCOMING
+## 4.0.0
 
+-   Remove option to use Codex since it is being deprecated by OpenAI, in favour of `gpt-3.5-turbo`.
+    -   Remove option from configuration
+    -   Remove all referecences in README and now explain that extension must be paid for
+    -   Refer to model as GPT-3.5 instead of ChatGPT in both README and configuraiton
 -   Re-add 3.3.0 into changelog, but keep 3.4.0 as well since both have been published
 
 ## 3.4.1

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # ChatGPT Helper
 
-This is an extension to quickly query OpenAI's [ChatGPT](https://openai.com/blog/chatgpt) or [Codex](https://openai.com/blog/openai-codex/) from VS Code.
+This is an extension to quickly query OpenAI's [ChatGPT](https://openai.com/blog/chatgpt) (GPT-3.5) from VS Code.
 
-ChatGPT is a large language model designed to answer general queries. The official ChatGPT API costs $0.002 / 1K tokens, where 1,000 tokens is approximately 750 words, so **$1 would buy approximately 2 million words**. To use this extension, you must provide an OpenAI API token; costs for using the API are charged directly to your OpenAI account.
+GPT-3.5, which powers ChatGPT, is a large language model designed to answer general queries. The official GPT-3.5 API costs $0.002 / 1K tokens, where 1,000 tokens is approximately 750 words, so **$1 would buy approximately 2 million words**.
 
-Alternatively, you can use Codex - another model by OpenAI specialised for code. This is the model used by GitHub Copilot. Codex is entirely free but still requires an API token in order to use.
+To use this extension, you must provide an OpenAI API token linked to an account with billing set up; costs for using the API are charged directly to your OpenAI account.
 
 ## Features
 
@@ -31,13 +31,15 @@ Use the "ChatGPT: Ask a question" command in the Command Palette:
 
 ## Authentication
 
-When you first query Codex, you will be prompted to enter an OpenAI API key. This is used by the extension to access the API and is only sent to OpenAI. Codex is currently free, so does not use up any credits on your account.
+When you first query ChatGPT, you will be prompted to enter an OpenAI API key. This is used by the extension to access the API and is only sent to OpenAI.
 
 To find your OpenAI API key:
 
 1. Go to https://platform.openai.com/account/api-keys. You will need to log in (or sign up) to your OpenAI account.
 2. Click "Create new secret key", and copy it.
 3. You should then paste it into VS Code when prompted.
+
+You must also have billing set up on your OpenAI account (see [Pricing](#pricing) below).
 
 ### Changing API key
 
@@ -49,25 +51,4 @@ Once your OpenAI API key has been set you can update it using the "ChatGPT: Chan
 
 ### Pricing
 
-While Codex (default) is entirely free, the ChatGPT API is charged by OpenAI at $0.002 / 1K tokens, charged directly to your OpenAI account. To use the ChatGPT model, you must set up billing on your account. Find more info about pricing at https://openai.com/pricing#chat.
-
-## Configuration
-
-### Switching Between Models
-
-In order to switch the model between Codex (default, free) and ChatGPT (paid), follow these instructions:
-
-1. `Ctrl` + `,` to open Preferences.
-2. Search for `chatgpt-helper.model`.
-3. Use the dropdown to switch between Codex and ChatGPT.
-
-### Changing Query Text
-
-> **Note**  
-> Currently, this is only available for the Codex model.
-
-In order to change the prompt sent to the AI that comes alongside your code, when running the code explanation/debug comnmands, follow these instructions:
-
-1. `Ctrl` + `,` to open Preferences.
-2. Search for `chatgpt-helper`.
-3. Change the relevant settings under `Codex > Queries` to whatever you want.
+The ChatGPT API is charged by OpenAI at $0.002 / 1K tokens, charged directly to your OpenAI account. To use this extension, you must set up billing on your account. Find more info about pricing at https://openai.com/pricing#chat.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "chatgpt-helper",
 	"displayName": "ChatGPT",
 	"description": "Make queries to OpenAI's ChatGPT from inside VS Code.",
-	"version": "3.4.1",
+	"version": "4.0.0",
 	"license": "GPL-3.0-or-later",
 	"engines": {
 		"vscode": "^1.73.0"

--- a/package.json
+++ b/package.json
@@ -68,30 +68,17 @@
 			"properties": {
 				"chatgpt-helper.model": {
 					"type": "string",
-					"default": "codex",
-					"markdownDescription": "The model (Codex or ChatGPT) to answer your queries with. More pricing info at https://openai.com/pricing#chat",
+					"default": "gpt-3.5",
+					"markdownDescription": "The model (currently only GPT-3.5) to answer your queries with. More pricing info at https://openai.com/pricing#chat",
 					"enum": [
-						"codex",
-						"chatgpt"
+						"gpt-3.5"
 					],
 					"enumItemLabels": [
-						"Codex (free)",
-						"ChatGPT (paid)"
+						"GPT-3.5"
 					],
 					"enumDescriptions": [
-						"Uses Codex, the engine that powers GitHub Copilot to answer your queries. This model is free and uses no OpenAI credits, but may produce lower quality results.",
-						"Uses ChatGPT to answer your queries. This produces higher quality results. This model uses OpenAI credits, which will be charged to your OpenAI account associated with the linked API key."
+						"Uses GPT-3.5 to answer your queries. This model uses OpenAI credits, which will be charged to your OpenAI account associated with the linked API key."
 					]
-				},
-				"chatgpt-helper.codex.queries.codeNotWorking": {
-					"type": "string",
-					"default": "\nExplanation from a helpful, creative, clever and friendly AI assistant of what is wrong with the code:",
-					"description": "The query to send to Codex when asking what is wrong with code. Will be sent alongside (after) the code."
-				},
-				"chatgpt-helper.codex.queries.explainCode": {
-					"type": "string",
-					"default": "\nExplanation from a helpful, creative, clever and friendly AI assistant of what the code does:",
-					"description": "The query to send to Codex when asking to explain code. Will be sent alongside (after) the code."
 				}
 			}
 		}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,90 +3,12 @@
 import * as vscode from "vscode"
 import * as https from "https"
 
-const getCommentOpening = (editor: vscode.TextEditor | undefined) => {
-	switch (editor?.document.languageId) {
-		case "c":
-		case "cpp":
-		case "csharp":
-		case "cuda-cpp":
-		case "objective-c":
-		case "objective-cpp":
-		case "go":
-		case "rust":
-		case "java":
-		case "scala":
-		case "kotlin":
-		case "scss":
-		case "swift":
-		case "typescript":
-		case "javascript":
-		case "javascriptreact":
-		case "coffeescript":
-		case "groovy":
-		case "php":
-			return "/*"
-		case "python":
-			return '"""'
-		case "ruby":
-			return "=begin"
-		case "perl":
-		case "perl6":
-			return "=pod"
-		case "r":
-			return "#"
-		default:
-			return "/*"
-	}
-}
-const getCommentEnding = (editor: vscode.TextEditor | undefined) => {
-	switch (editor?.document.languageId) {
-		case "c":
-		case "cpp":
-		case "csharp":
-		case "cuda-cpp":
-		case "objective-c":
-		case "objective-cpp":
-		case "go":
-		case "rust":
-		case "java":
-		case "scala":
-		case "kotlin":
-		case "scss":
-		case "swift":
-		case "typescript":
-		case "javascript":
-		case "javascriptreact":
-		case "coffeescript":
-		case "groovy":
-		case "php":
-			return /\*\/$/m
-		case "python":
-			return /""""$/m
-		case "ruby":
-			return /=end$/m
-		case "perl":
-		case "perl6":
-			return /=cut$/m
-		case "r":
-			return /#$/m
-		default:
-			return /\*\/$/m
-	}
-}
-
-const sendQueryToOpenAI = async (
-	queryText: string,
-	openAIKey: string,
-	commentClosing?: RegExp,
-) => {
+const sendQueryToOpenAI = async (queryText: string, openAIKey: string) => {
 	// get user or workspace configuration object
 	let config = vscode.workspace.getConfiguration()
-	const model = config.get("chatgpt-helper.model") as string | null
-	const modelId = model === "chatgpt" ? "gpt-3.5-turbo" : "code-davinci-002"
-	const modelNameReadable = model === "chatgpt" ? "ChatGPT" : "Codex"
 
 	const outputDocument = await vscode.workspace.openTextDocument({
-		content: `Querying ${modelNameReadable}. This may take some time...`,
+		content: `Querying ChatGPT. This may take some time...`,
 		language: "markdown",
 	})
 	const outputDocumentEditor = await vscode.window.showTextDocument(
@@ -104,8 +26,7 @@ const sendQueryToOpenAI = async (
 	const request = https.request(
 		{
 			hostname: "api.openai.com",
-			path:
-				model === "codex" ? "/v1/completions" : "/v1/chat/completions",
+			path: "/v1/chat/completions",
 			method: "POST",
 			headers: {
 				"Content-Type": "application/json", // eslint-disable-line @typescript-eslint/naming-convention
@@ -115,48 +36,29 @@ const sendQueryToOpenAI = async (
 		response => {
 			response.on("data", data => {
 				process.stdout.write(data)
-				if (model === "codex") {
-					responseText += JSON.parse(
-						data.toString(),
-					).choices[0].text.trim()
-					if (commentClosing) {
-						responseText = responseText.replace(commentClosing, "")
-					}
-				} else {
-					responseText += JSON.parse(data.toString()).choices[0]
-						.message.content
-				}
+				responseText += JSON.parse(data.toString()).choices[0].message
+					.content
 			})
 		},
 	)
 
 	request.write(
-		JSON.stringify(
-			model === "codex"
-				? {
-						model: "code-davinci-002",
-						prompt: entireQueryText,
-						temperature: 0.1,
-						max_tokens: 512, // eslint-disable-line @typescript-eslint/naming-convention
-						frequency_penalty: 0.38, // eslint-disable-line @typescript-eslint/naming-convention
-				  }
-				: {
-						model: "gpt-3.5-turbo",
-						max_tokens: 512, // eslint-disable-line @typescript-eslint/naming-convention
-						// todo: should subtract length (in tokens) of query
-						messages: [
-							{
-								role: "system",
-								content:
-									"You are a knowledgeable and helpful assistant called ChatGPT, who is specialised to help answer queries about users' code.",
-							},
-							{
-								role: "user",
-								content: entireQueryText,
-							},
-						],
-				  },
-		),
+		JSON.stringify({
+			model: "gpt-3.5-turbo",
+			max_tokens: 512, // eslint-disable-line @typescript-eslint/naming-convention
+			// todo: should subtract length (in tokens) of query
+			messages: [
+				{
+					role: "system",
+					content:
+						"You are a knowledgeable and helpful assistant called ChatGPT, who is specialised to help answer queries about users' code.",
+				},
+				{
+					role: "user",
+					content: entireQueryText,
+				},
+			],
+		}),
 	)
 	request.end()
 	request.on("close", () => {
@@ -179,7 +81,7 @@ const sendQueryToOpenAI = async (
 					new vscode.Position(0, 0),
 					new vscode.Position(99999999999999, 0),
 				),
-				`Error querying ${modelNameReadable}.\n\n${error}`,
+				`Error querying ChatGPT.\n\n${error}`,
 			)
 		})
 	})
@@ -225,32 +127,9 @@ export function activate(context: vscode.ExtensionContext) {
 			const codeToQuery = selectedCode || entireFileContents
 
 			if (codeToQuery) {
-				const workspaceConfiguration =
-					vscode.workspace.getConfiguration()
-				const commentOpening = getCommentOpening(
-					vscode.window.activeTextEditor,
-				)
-				const commentEnding = getCommentEnding(
-					vscode.window.activeTextEditor,
-				)
-				const model = workspaceConfiguration.get(
-					"chatgpt-helper.model",
-				) as string
 				const fullQueryText =
-					model === "chatgpt"
-						? "Why is the following code not working?\n" +
-						  codeToQuery
-						: codeToQuery +
-						  "\n" +
-						  commentOpening +
-						  (workspaceConfiguration.get(
-								"chatgpt-helper.codex.queries.codeNotWorking",
-						  ) as string | null)
-				sendQueryToOpenAI(
-					fullQueryText,
-					await getOpenAIKey(),
-					commentEnding,
-				)
+					"Why is the following code not working?\n" + codeToQuery
+				sendQueryToOpenAI(fullQueryText, await getOpenAIKey())
 			} else {
 				vscode.window.showErrorMessage(
 					"No code selected or file is empty. Did not send to ChatGPT",
@@ -277,31 +156,9 @@ export function activate(context: vscode.ExtensionContext) {
 			const codeToQuery = selectedCode || entireFileContents
 
 			if (codeToQuery) {
-				const workspaceConfiguration =
-					vscode.workspace.getConfiguration()
-				const commentOpening = getCommentOpening(
-					vscode.window.activeTextEditor,
-				)
-				const commentEnding = getCommentEnding(
-					vscode.window.activeTextEditor,
-				)
-				const model = workspaceConfiguration.get(
-					"chatgpt-helper.model",
-				) as string
 				const fullQueryText =
-					model === "chatgpt"
-						? "Explain the following code:\n" + codeToQuery
-						: codeToQuery +
-						  "\n" +
-						  commentOpening +
-						  (workspaceConfiguration.get(
-								"chatgpt-helper.codex.queries.explainCode",
-						  ) as string | null)
-				sendQueryToOpenAI(
-					fullQueryText,
-					await getOpenAIKey(),
-					commentEnding,
-				)
+					"Explain the following code:\n" + codeToQuery
+				sendQueryToOpenAI(fullQueryText, await getOpenAIKey())
 			} else {
 				vscode.window.showErrorMessage(
 					"No code selected or file is empty. Did not send to ChatGPT",


### PR DESCRIPTION
being discontinued by openai:

> On March 23rd, we will discontinue support for the Codex API. All customers will have to transition to a different model. Codex was initially introduced as a free limited beta in 2021, and has maintained that status to date. Given the advancements of our newest GPT-3.5 models for coding tasks, we will no longer be supporting Codex and encourage all customers to transition to GPT-3.5-Turbo.
> About GPT-3.5-Turbo
> GPT-3.5-Turbo is the most cost effective and performant model in the GPT-3.5 family. It can both do coding tasks while also being complemented with flexible natural language capabilities.
> 
> You can learn more through:
> GPT-3.5 model overview
> Chat completions guide
> 
> Models affected
> The following models will be discontinued:
> code-cushman:001
> code-cushman:002
> code-davinci:001
> code-davinci:002
> 
> We understand this transition may be temporarily inconvenient, but we are confident it will allow us to increase our investment in our latest and most capable models.
> 
> —The OpenAI team